### PR TITLE
fixes issue of the same filename appearing

### DIFF
--- a/public/js/upload.js
+++ b/public/js/upload.js
@@ -7,10 +7,11 @@ function init() {
 function handleFileSelect(event) {
     if(!event.target.files) return;
     const files = event.target.files;
-    const selected = document.querySelector("#selectedFiles ul");
-    selected.innerHTML = "";
-    for(var i=0; i<files.length; i++) {
-        const file = files[i];
-        selected.innerHTML += "<li>" + file.name + "<br/>" + "</li>";
-    }
+    const selectedList = document.querySelector('#selectedFiles ul');
+
+    Array.from(files).map(function (file) {
+        var li = document.createElement('li');
+        li.appendChild(document.createTextNode(file.name));
+        selectedList.appendChild(li);
+    });
 }


### PR DESCRIPTION
also uses `appendChild` for adding to the DOM

relates to changes in https://github.com/guardian/s3-upload/pull/3

before - if you choose multiple files, the filenames are all the same!
![filename](https://cloud.githubusercontent.com/assets/836140/13773357/befb3f6c-ea90-11e5-9951-036461fc4d83.gif)

after
![filename - after](https://cloud.githubusercontent.com/assets/836140/13773393/e9f3a75e-ea90-11e5-8a33-3ac5445592b3.gif)
