### PR TITLE
Upgrade AWS SDK

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ def env(key: String): Option[String] = Option(System.getenv(key))
 
 libraryDependencies ++= Seq(
   cache, ws, filters,
-  "com.amazonaws" % "aws-java-sdk-s3" % "1.10.44",
+  "com.amazonaws" % "aws-java-sdk-s3" % "1.11.423",
   "com.gu" %% "pan-domain-auth-verification" % "0.2.10"
 )
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.9
+sbt.version=0.13.17

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -7,3 +7,5 @@ addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.4.6")
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.0.6")
 
 addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "0.9.7")
+
+addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.9.2")


### PR DESCRIPTION
To cover off Snyk reported vulnerability.

`sbt-dependency-graph` is required to run `snyk test` locally