### PR TITLE
CHARTS TOOL: Allow charts tool to post files to S3

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,15 @@ sbt run
 
 ### App
 To deploy the app, deploy the project `media-service::teamcity::s3-uploader` in riffraff.
+
+
+### Adding a new service
+If you want another service or app to access the endpoints in s3-uploader (allowing it to upload to s3), there are a 
+couple of steps to follow:
+* Add an new Config object for your service in `Config.scala`. Some other configuration is in the Cloudformation stack 
+in editorial-tools-platform
+* Add the hostname of the new service to the 'Allowed Origins' in `application.conf`. Locally this file is in the repo.
+For CODE and PROD, it is in S3 in the `media-service` account
+* If required, add a new route and method to handle the new request
+* Cross account access etc can be configured at the bucket policy level in S3
+  

--- a/app/AppComponents.scala
+++ b/app/AppComponents.scala
@@ -26,5 +26,4 @@ class AppComponents(context: Context) extends BuiltInComponentsFromContext(conte
   final override def httpFilters: Seq[EssentialFilter] = corsFilter +: super.httpFilters.filterNot(disabledFilters.contains)
 
   override def router: Router = new Routes(httpErrorHandler, api, assets, management)
-
 }

--- a/app/AppComponents.scala
+++ b/app/AppComponents.scala
@@ -7,21 +7,28 @@ import play.api.BuiltInComponentsFromContext
 import play.api.mvc.EssentialFilter
 import play.api.routing.Router
 import play.filters.HttpFiltersComponents
+import play.filters.cors.CORSConfig.Origins
+import play.filters.cors.{CORSComponents, CORSConfig, CORSFilter}
 import router.Routes
 
-class AppComponents(context: Context) extends BuiltInComponentsFromContext(context: Context) with HttpFiltersComponents with AssetsComponents {
-  val s3Client = AmazonS3ClientBuilder.standard().withRegion(Config.region).withCredentials(Config.awsCredentials).build()
-  val s3Actions = new S3Actions(s3Client)
 
-  val publicSettings = new PublicSettings(s"${Config.domain}.settings.public", "pan-domain-auth-settings", s3Client)
+class AppComponents(context: Context) extends BuiltInComponentsFromContext(context: Context) with HttpFiltersComponents with AssetsComponents with CORSComponents {
+
+
+  val s3Actions = new S3Actions()
+
+  val publicSettings = new PublicSettings(s"${Config.domain}.settings.public", "pan-domain-auth-settings", Config.s3Client)
 
   publicSettings.start()
 
   val api = new Application(s3Actions, publicSettings, controllerComponents)
   val management = new Management(controllerComponents)
 
+  override lazy val corsConfig: CORSConfig = CORSConfig.fromConfiguration(configuration).copy(allowedOrigins = Origins.Matching(_ == Config.chartsToolOrigin))
+
   val disabledFilters: Set[EssentialFilter] = Set(allowedHostsFilter)
-  final override def httpFilters: Seq[EssentialFilter] = super.httpFilters.filterNot(disabledFilters.contains)
+  final override def httpFilters: Seq[EssentialFilter] = corsFilter +: super.httpFilters.filterNot(disabledFilters.contains)
 
   override def router: Router = new Routes(httpErrorHandler, api, assets, management)
+
 }

--- a/app/AppComponents.scala
+++ b/app/AppComponents.scala
@@ -1,14 +1,12 @@
-import com.amazonaws.services.s3.AmazonS3ClientBuilder
 import com.gu.pandomainauth.PublicSettings
 import controllers.{Application, AssetsComponents, Management}
-import lib.{Config, S3Actions}
+import lib.{S3Actions, S3UploadAppConfig}
 import play.api.ApplicationLoader.Context
 import play.api.BuiltInComponentsFromContext
 import play.api.mvc.EssentialFilter
 import play.api.routing.Router
 import play.filters.HttpFiltersComponents
-import play.filters.cors.CORSConfig.Origins
-import play.filters.cors.{CORSComponents, CORSConfig, CORSFilter}
+import play.filters.cors.{CORSComponents}
 import router.Routes
 
 
@@ -17,14 +15,12 @@ class AppComponents(context: Context) extends BuiltInComponentsFromContext(conte
 
   val s3Actions = new S3Actions()
 
-  val publicSettings = new PublicSettings(s"${Config.domain}.settings.public", "pan-domain-auth-settings", Config.s3Client)
+  val publicSettings = new PublicSettings(s"${S3UploadAppConfig.domain}.settings.public", "pan-domain-auth-settings", S3UploadAppConfig.s3Client)
 
   publicSettings.start()
 
   val api = new Application(s3Actions, publicSettings, controllerComponents)
   val management = new Management(controllerComponents)
-
-  override lazy val corsConfig: CORSConfig = CORSConfig.fromConfiguration(configuration).copy(allowedOrigins = Origins.Matching(_ == Config.chartsToolOrigin))
 
   val disabledFilters: Set[EssentialFilter] = Set(allowedHostsFilter)
   final override def httpFilters: Seq[EssentialFilter] = corsFilter +: super.httpFilters.filterNot(disabledFilters.contains)

--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -52,7 +52,6 @@ class Application(s3Actions: S3Actions, override val publicSettings: PublicSetti
   private def bytesToMb (bytes: Long): Long = bytes / 1024 / 1024
 
   def uploadFile = AuthAction (parse.maxLength(parse.DefaultMaxDiskLength, parse.multipartFormData)) { request =>
-
     request.body match {
       case Left(MaxSizeExceeded(limit)) => {
         EntityTooLarge(views.html.tooLarge(request.user, bytesToMb(limit)))

--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -39,18 +39,10 @@ class Application(s3Actions: S3Actions, override val publicSettings: PublicSetti
           Files.delete(temporaryFilePath)
           res
         }
-        
 
         uploads.head match {
-          case e: S3UploadFailure => InternalServerError(e.msg.getOrElse("Upload failed!"))
-          case s: S3UploadSuccess => {
-            val successJson = Json.parse(
-              s"""
-              { "s3url" : "${s.directToS3Url.get.toString}",
-                "url" : "${s.url.get.toString}" }
-              """)
-            Ok( successJson )
-          }
+          case failure: S3UploadFailure => InternalServerError(Json.toJson(failure))
+          case success: S3UploadSuccess => Ok(Json.toJson(success))
         }
       }
     }
@@ -61,7 +53,9 @@ class Application(s3Actions: S3Actions, override val publicSettings: PublicSetti
   }
 
   private def getChartKey() = {
-    "charts/embed/test8.html"
+    val now = Calendar.getInstance().getTime
+    val dateFormat = new SimpleDateFormat("MMM/yyyy-MM-dd-hh:mm:ss")
+    s"${dateFormat.format(now).toLowerCase}/embed.html"
   }
 
   private def getCurrentDate = {
@@ -69,7 +63,6 @@ class Application(s3Actions: S3Actions, override val publicSettings: PublicSetti
     val dateFormat = new SimpleDateFormat("yyyy/MM/dd")
     dateFormat.format(now)
   }
-
 
   private def bytesToMb (bytes: Long): Long = bytes / 1024 / 1024
 

--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -22,6 +22,8 @@ class Application(s3Actions: S3Actions, override val publicSettings: PublicSetti
   private def bytesToMb (bytes: Long): Long = bytes / 1024 / 1024
 
   def uploadFile = AuthAction (parse.maxLength(parse.DefaultMaxDiskLength, parse.multipartFormData)) { request =>
+
+    println("=====>", request)
     request.body match {
       case Left(MaxSizeExceeded(limit)) => {
         EntityTooLarge(views.html.tooLarge(request.user, bytesToMb(limit)))

--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -35,7 +35,7 @@ class Application(s3Actions: S3Actions, override val publicSettings: PublicSetti
           val temporaryFilePath = Paths.get(s"/tmp/${f.filename}")
           f.ref.moveFileTo(temporaryFilePath, replace = true)
 
-          val res = s3Actions.upload(temporaryFilePath.toFile, request.user, Config.interactivesBucketName, Config.s3ClientUS, getChartKey(), setPublicAcl = true)
+          val res = s3Actions.upload(temporaryFilePath.toFile, request.user, ChartsToolConfig, setPublicAcl = true)
           Files.delete(temporaryFilePath)
           res
         }
@@ -48,21 +48,6 @@ class Application(s3Actions: S3Actions, override val publicSettings: PublicSetti
     }
   }
 
-  private def getS3Key(file: File) = {
-    s"$getCurrentDate/${file.getName.replace(' ', '_')}"
-  }
-
-  private def getChartKey() = {
-    val now = Calendar.getInstance().getTime
-    val dateFormat = new SimpleDateFormat("MMM/yyyy-MM-dd-hh:mm:ss")
-    s"${dateFormat.format(now).toLowerCase}/embed.html"
-  }
-
-  private def getCurrentDate = {
-    val now = Calendar.getInstance().getTime
-    val dateFormat = new SimpleDateFormat("yyyy/MM/dd")
-    dateFormat.format(now)
-  }
 
   private def bytesToMb (bytes: Long): Long = bytes / 1024 / 1024
 
@@ -78,7 +63,7 @@ class Application(s3Actions: S3Actions, override val publicSettings: PublicSetti
           val temporaryFilePath = Paths.get(s"/tmp/${f.filename}")
           f.ref.moveFileTo(temporaryFilePath, replace = true)
 
-          val res = s3Actions.upload(temporaryFilePath.toFile, request.user, Config.bucketName, Config.s3Client, getS3Key(temporaryFilePath.toFile), setPublicAcl = false)
+          val res = s3Actions.upload(temporaryFilePath.toFile, request.user, S3UploadAppConfig, setPublicAcl = false)
           Files.delete(temporaryFilePath)
           res
         }

--- a/app/lib/Config.scala
+++ b/app/lib/Config.scala
@@ -1,16 +1,25 @@
 package lib
 
-import java.io.FileNotFoundException
+import java.io.{File, FileNotFoundException}
 import java.net.URI
+import java.text.SimpleDateFormat
+import java.util.Calendar
 
 import com.amazonaws.auth.profile.ProfileCredentialsProvider
 import com.amazonaws.auth.{AWSCredentialsProviderChain, InstanceProfileCredentialsProvider}
-import com.amazonaws.services.s3.AmazonS3ClientBuilder
-
+import com.amazonaws.services.s3.{AmazonS3, AmazonS3ClientBuilder}
 import scala.io.Source
 import scala.util.Try
 
-object Config {
+trait Config {
+
+  // config properties required for each new app using the S3-Uploader
+  val bucketName: String
+  val region: String
+  val s3Client: AmazonS3
+  def key (fileName: String): String
+  val prettyUrl: String
+
   val properties: Map[String, String] = Try(Properties.fromPath("/etc/gu/s3-uploader.properties")).getOrElse(Map.empty)
 
   val awsCredentials = new AWSCredentialsProviderChain(
@@ -18,20 +27,9 @@ object Config {
     InstanceProfileCredentialsProvider.getInstance()
   )
 
-  val region = properties.getOrElse("aws.region", "eu-west-1")
-
-  val interactivesBucketRegion = properties.getOrElse("aws.region", "us-east-1")
-
-  val bucketName = properties.getOrElse("s3.bucket", "s3-uploader-dev-bucket")
-
-  val interactivesBucketName = properties.getOrElse("s3.bucket", "gdn-cdn")
-
   val domain = properties.getOrElse("panda.domain", "local.dev-gutools.co.uk")
 
   val loginUri = new URI(s"https://login.$domain/login?returnUrl=https://s3-uploader.$domain")
-
-  val s3Client = AmazonS3ClientBuilder.standard().withRegion(Config.region).withCredentials(Config.awsCredentials).build()
-  val s3ClientUS = AmazonS3ClientBuilder.standard().withRegion(Config.interactivesBucketRegion).withCredentials(Config.awsCredentials).build()
 
   implicit val stage : String = {
     try {
@@ -45,5 +43,31 @@ object Config {
     }
   }
 
-  val chartsToolOrigin = "https://charts." + domain
+}
+
+object S3UploadAppConfig extends Config {
+  val bucketName = properties.getOrElse("s3.bucket", "s3-uploader-dev-bucket")
+  val region = properties.getOrElse("aws.region", "eu-west-1")
+  val s3Client = AmazonS3ClientBuilder.standard().withRegion(region).withCredentials(awsCredentials).build()
+  val prettyUrl = "https://uploads.guim.co.uk"
+
+  def key(fileName: String) = {
+    val now = Calendar.getInstance().getTime
+    val dateFormat = new SimpleDateFormat("yyyy/MM/dd")
+    val getCurrentDate = dateFormat.format(now)
+    s"$getCurrentDate/${fileName.replace(' ', '_')}"
+  }
+}
+
+object ChartsToolConfig extends Config {
+  val bucketName = properties.getOrElse("s3.chartBucket", "gdn-cdn")
+  val region = properties.getOrElse("aws.chartRegion", "us-east-1")
+  val s3Client = AmazonS3ClientBuilder.standard().withRegion(region).withCredentials(awsCredentials).build()
+  val prettyUrl = "https://interactive.guim.co.uk"
+
+  def key(fileName: String) = {
+    val now = Calendar.getInstance().getTime
+    val dateFormat = new SimpleDateFormat("MMM/yyyy-MM-dd-hh:mm:ss")
+    s"charts/embed/${dateFormat.format(now).toLowerCase}/embed.html"
+  }
 }

--- a/app/lib/Config.scala
+++ b/app/lib/Config.scala
@@ -5,6 +5,7 @@ import java.net.URI
 
 import com.amazonaws.auth.profile.ProfileCredentialsProvider
 import com.amazonaws.auth.{AWSCredentialsProviderChain, InstanceProfileCredentialsProvider}
+import com.amazonaws.services.s3.AmazonS3ClientBuilder
 
 import scala.io.Source
 import scala.util.Try
@@ -19,11 +20,18 @@ object Config {
 
   val region = properties.getOrElse("aws.region", "eu-west-1")
 
+  val interactivesBucketRegion = properties.getOrElse("aws.region", "us-east-1")
+
   val bucketName = properties.getOrElse("s3.bucket", "s3-uploader-dev-bucket")
+
+  val interactivesBucketName = properties.getOrElse("s3.bucket", "gdn-cdn")
 
   val domain = properties.getOrElse("panda.domain", "local.dev-gutools.co.uk")
 
   val loginUri = new URI(s"https://login.$domain/login?returnUrl=https://s3-uploader.$domain")
+
+  val s3Client = AmazonS3ClientBuilder.standard().withRegion(Config.region).withCredentials(Config.awsCredentials).build()
+  val s3ClientUS = AmazonS3ClientBuilder.standard().withRegion(Config.interactivesBucketRegion).withCredentials(Config.awsCredentials).build()
 
   implicit val stage : String = {
     try {
@@ -36,4 +44,6 @@ object Config {
       case e: FileNotFoundException => "DEV"
     }
   }
+
+  val chartsToolOrigin = "https://charts." + domain
 }

--- a/app/lib/Config.scala
+++ b/app/lib/Config.scala
@@ -12,7 +12,6 @@ import scala.io.Source
 import scala.util.Try
 
 trait Config {
-
   // config properties required for each new app using the S3-Uploader
   val bucketName: String
   val region: String
@@ -42,8 +41,8 @@ trait Config {
       case e: FileNotFoundException => "DEV"
     }
   }
-
 }
+
 
 object S3UploadAppConfig extends Config {
   val bucketName = properties.getOrElse("s3.bucket", "s3-uploader-dev-bucket")
@@ -58,6 +57,7 @@ object S3UploadAppConfig extends Config {
     s"$getCurrentDate/${fileName.replace(' ', '_')}"
   }
 }
+
 
 object ChartsToolConfig extends Config {
   val bucketName = properties.getOrElse("s3.chartBucket", "gdn-cdn")

--- a/app/lib/PanAuth.scala
+++ b/app/lib/PanAuth.scala
@@ -37,8 +37,6 @@ trait PandaController extends BaseControllerHelpers with Logging {
       publicSettings.publicKey match {
         case Some(pk) =>
 
-
-          println("in auth action, request.cookies", request.cookies)
           request.cookies.get("gutoolsAuth-assym") match {
             case Some(cookie) =>
               authStatus(cookie, pk) match {

--- a/app/lib/PanAuth.scala
+++ b/app/lib/PanAuth.scala
@@ -33,10 +33,8 @@ trait PandaController extends BaseControllerHelpers with Logging {
     override protected def executionContext: ExecutionContext = PandaController.this.controllerComponents.executionContext
 
     override def invokeBlock[A](request: Request[A], block: UserRequest[A] => Future[Result]): Future[Result] = {
-
       publicSettings.publicKey match {
         case Some(pk) =>
-
           request.cookies.get("gutoolsAuth-assym") match {
             case Some(cookie) =>
               authStatus(cookie, pk) match {

--- a/app/lib/PanAuth.scala
+++ b/app/lib/PanAuth.scala
@@ -14,7 +14,7 @@ trait PandaController extends BaseControllerHelpers with Logging {
   def publicSettings: PublicSettings
 
   def unauthorisedResponse[A](request: Request[A]) = {
-    Future.successful(Unauthorized(views.html.login(Config.loginUri)(request)))
+    Future.successful(Unauthorized(views.html.login(S3UploadAppConfig.loginUri)(request)))
   }
 
   def authStatus(cookie: Cookie, publicKey: PublicKey): AuthenticationStatus = {

--- a/app/lib/PanAuth.scala
+++ b/app/lib/PanAuth.scala
@@ -33,8 +33,12 @@ trait PandaController extends BaseControllerHelpers with Logging {
     override protected def executionContext: ExecutionContext = PandaController.this.controllerComponents.executionContext
 
     override def invokeBlock[A](request: Request[A], block: UserRequest[A] => Future[Result]): Future[Result] = {
+
       publicSettings.publicKey match {
         case Some(pk) =>
+
+
+          println("in auth action, request.cookies", request.cookies)
           request.cookies.get("gutoolsAuth-assym") match {
             case Some(cookie) =>
               authStatus(cookie, pk) match {

--- a/app/lib/S3Actions.scala
+++ b/app/lib/S3Actions.scala
@@ -2,12 +2,12 @@ package lib
 
 import java.io.File
 import java.net.URI
-import java.text.SimpleDateFormat
-import java.util.Calendar
 
-import com.amazonaws.services.s3.{AmazonS3, AmazonS3ClientBuilder}
+import com.amazonaws.services.s3.AmazonS3
 import com.amazonaws.services.s3.model._
 import com.gu.pandomainauth.model.User
+import play.api.libs.json.{JsPath, JsString, JsValue, Writes}
+import play.api.libs.functional.syntax._
 
 trait S3UploadResponse {
   def url: Option[URI]
@@ -33,6 +33,17 @@ object S3UploadResponse {
     
     S3UploadSuccess(Some(new URI(uri)), Some(new URI(directToS3Uri)), Some(putObjectRequest.getKey), None)
   }
+
+  implicit val writesUri: Writes[URI] = (uri: URI) => JsString(uri.toString)
+
+  implicit val s3UploadSuccessWrites: Writes[S3UploadSuccess] = (
+    (JsPath \ "url").writeNullable[URI] and
+    (JsPath \ "directToS3Url").writeNullable[URI] and
+    (JsPath \ "fileName").writeNullable[String] and
+    (JsPath \ "msg").writeNullable[String]
+  )(unlift(S3UploadSuccess.unapply))
+
+  implicit val s3UploadFailureWrites: Writes[S3UploadFailure] = (failure: S3UploadFailure) => JsString(failure.msg.getOrElse("Something went wrong"))
 }
 
 class S3Actions() {

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -4,8 +4,6 @@ play.http.secret.key="%APPLICATION_SECRET%"
 play.application.langs="en"
 
 play.http.session.secure=true
-play.filters.enabled += "play.filters.cors.CORSFilter"
-
 
 logger.root=ERROR
 logger.play=INFO
@@ -15,11 +13,10 @@ play.http.parser.maxDiskBuffer=50M
 
 
 play.filters.cors {
-  allowedOrigins = ["https://charts.code.dev-gutools.co.uk"]
+  allowedOrigins = ["https://charts.local.dev-gutools.co.uk"]
   allowedHttpMethods = ["GET", "POST", "OPTIONS"]
   preflightMaxAge = 3 days
   supportsCredentials = true
-  allowedHttpHeaders = ["Accept", "SameSite"]
 }
 
 

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -18,5 +18,3 @@ play.filters.cors {
   preflightMaxAge = 3 days
   supportsCredentials = true
 }
-
-

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -4,9 +4,22 @@ play.http.secret.key="%APPLICATION_SECRET%"
 play.application.langs="en"
 
 play.http.session.secure=true
+play.filters.enabled += "play.filters.cors.CORSFilter"
+
 
 logger.root=ERROR
 logger.play=INFO
 logger.application=DEBUG
 
 play.http.parser.maxDiskBuffer=50M
+
+
+play.filters.cors {
+  allowedOrigins = ["https://charts.code.dev-gutools.co.uk"]
+  allowedHttpMethods = ["GET", "POST", "OPTIONS"]
+  preflightMaxAge = 3 days
+  supportsCredentials = true
+  allowedHttpHeaders = ["Accept", "SameSite"]
+}
+
+

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -13,7 +13,7 @@ play.http.parser.maxDiskBuffer=50M
 
 
 play.filters.cors {
-  allowedOrigins = ["https://charts.local.dev-gutools.co.uk"]
+  allowedOrigins = ["https://charts.local.dev-gutools.co.uk", "https://s3-uploader.local.dev-gutools.co.uk"]
   allowedHttpMethods = ["GET", "POST", "OPTIONS"]
   preflightMaxAge = 3 days
   supportsCredentials = true

--- a/conf/routes
+++ b/conf/routes
@@ -6,6 +6,7 @@
 GET     /                           controllers.Application.index
 GET     /upload                     controllers.Application.upload
 POST    /upload                     controllers.Application.uploadFile
+POST    /upload-chart               controllers.Application.uploadChart
 
 # Map static resources from the /public folder to the /assets URL path
 GET     /assets/*file               controllers.Assets.at(path="/public", file)


### PR DESCRIPTION
We wanted another Guardian tool to be able to use the S3-uploader to put files in S3. Previously the S3-uploader only accepted uploads via its own user interface at `https://s3-uploader.gutools.co.uk/`

## Why
The other tool (the [Charts tool](https://github.com/guardian/interactive-basichartool)) is a purely client-side app so getting AWS credentials into it is fiddly. It's simpler and safer for the Charts Tool to simply make a POST request with the data. 

The S3 uploader already has the required combination of Google Auth checks (Panda etc) and S3 credentials - so we believed org didn't need another way to upload to S3 and we should use the one that already exists. 

## What
* Added a new endpoint specific to the charts tool `/upload-chart` allowing POST requests. 

* Breaking out the config. Because we wanted data from the charts tool to be treated slightly differently. We broke out a new Config object specifically for Charts Tool requests. This contains a different s3Bucket among other pieces of config. 

* To allow for the cross-account posting we want we also had to add a specific policy to the S3 Bucket we are using. 

* We added a new function `uploadChart` allowing for specific return values - we just want the tool to know the success / failure and the url where the chart has been uploaded. 

### CORS changes 

* To allow the Charts Tool to hit this endpoint we needed to add a new CORS configuration, because for the first time, s3-upload had to deal with Cross-Origin requests. 

- The response needed a `Allowed Origin` header for the request so we added `https://charts.gutools.co.uk` to this. Because requests from the s3-uploader's own UI now get pushed through the CORS filter, we also need to add its own UI to this `https://s3-uploader.gutools.co.uk` so it will be accepted. 

- The response needs to support credentials - ie. accept the panda auth cookie that the request sends 

- Play uses http filters to create requests / responses so this is where we made these changes 

## Future work 

Ideally, we would eliminate duplication in the `Application` controller by using parameterized routes to determine which config objects to use. 

New services would still need a config object, but adding one would be simpler and the "upload" functionality would be more flexible. 

