### PR TITLE
Moved Xenial AMI to Bionic as it is no longer supported

### DIFF
--- a/conf/riff-raff.yaml
+++ b/conf/riff-raff.yaml
@@ -13,7 +13,7 @@ deployments:
     app: s3-uploader
     parameters:
       amiTags:
-        Recipe: editorial-tools-xenial-java8
+        Recipe: editorial-tools-bionic-java8
         AmigoStage: PROD
         BuiltBy: amigo
       cloudFormationStackName: s3-uploader


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
Moves AMI from Xenial to Bionic because Xenial is no longer supported.

This branch has been [successfully deployed to CODE](https://riffraff.gutools.co.uk/deployment/view/bb0bd0a6-7df8-435e-ba8b-022574ff749b) via RiffRaff.

Related card [here](https://trello.com/c/NLpikw2C/2330-update-xenial-amis-to-use-bionic).

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
Deploy to [CODE](https://s3-uploader.code.dev-gutools.co.uk/) via RiffRaff (it's under `media-service::teamcity::s3-uploader`), and ensure it deploys and runs correctly.