### PR TITLE
Version assets

### DIFF
--- a/app/views/index.scala.html
+++ b/app/views/index.scala.html
@@ -36,6 +36,6 @@
         </div>
 
     </div>
-    <script src="@routes.Assets.at("js/upload.js")"></script>
+    <script src="@routes.Assets.versioned("js/upload.js")"></script>
 
 }

--- a/app/views/login.scala.html
+++ b/app/views/login.scala.html
@@ -6,9 +6,9 @@
 <html lang="en">
     <head>
         <title>Login | S3 Uploader</title>
-        <link rel="shortcut icon" type="image/png" href="@routes.Assets.at("images/favicon.png")">
-        <link rel="stylesheet" href="@routes.Assets.at("js/node_modules/material-design-lite/material.min.css")">
-        <link rel="stylesheet" media="screen" href="@routes.Assets.at("stylesheets/main.css")">
+        <link rel="shortcut icon" type="image/png" href="@routes.Assets.versioned("images/favicon.png")">
+        <link rel="stylesheet" href="@routes.Assets.versioned("js/node_modules/material-design-lite/material.min.css")">
+        <link rel="stylesheet" media="screen" href="@routes.Assets.versioned("stylesheets/main.css")">
         <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
     </head>
 
@@ -28,6 +28,6 @@
             </main>
         </div>
 
-        <script src="@routes.Assets.at("js/node_modules/material-design-lite/material.min.js")"></script>
+        <script src="@routes.Assets.versioned("js/node_modules/material-design-lite/material.min.js")"></script>
     </body>
 </html>

--- a/app/views/main.scala.html
+++ b/app/views/main.scala.html
@@ -6,9 +6,9 @@
 <html lang="en">
     <head>
         <title>@title | S3 Uploader</title>
-        <link rel="shortcut icon" type="image/png" href="@routes.Assets.at("images/favicon.png")">
-        <link rel="stylesheet" href="@routes.Assets.at("js/node_modules/material-design-lite/material.min.css")">
-        <link rel="stylesheet" media="screen" href="@routes.Assets.at("stylesheets/main.css")">
+        <link rel="shortcut icon" type="image/png" href="@routes.Assets.versioned("images/favicon.png")">
+        <link rel="stylesheet" href="@routes.Assets.versioned("js/node_modules/material-design-lite/material.min.css")">
+        <link rel="stylesheet" media="screen" href="@routes.Assets.versioned("stylesheets/main.css")">
         <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
     </head>
 
@@ -40,6 +40,6 @@
             </main>
         </div>
 
-        <script src="@routes.Assets.at("js/node_modules/material-design-lite/material.min.js")"></script>
+        <script src="@routes.Assets.versioned("js/node_modules/material-design-lite/material.min.js")"></script>
     </body>
 </html>

--- a/build.sbt
+++ b/build.sbt
@@ -26,6 +26,8 @@ lazy val root = (project in file("."))
   .settings(
     playDefaultPort := 9050,
 
+    pipelineStages := Seq(digest, gzip),
+
     riffRaffPackageName := s"media-service::teamcity::${name.value}",
     riffRaffManifestProjectName := s"${riffRaffPackageName.value}",
     riffRaffUploadArtifactBucket := Option("riffraff-artifact"),

--- a/conf/routes
+++ b/conf/routes
@@ -9,6 +9,6 @@ POST    /upload                     controllers.Application.uploadFile
 POST    /upload-chart               controllers.Application.uploadChart
 
 # Map static resources from the /public folder to the /assets URL path
-GET     /assets/*file               controllers.Assets.at(path="/public", file)
+GET     /assets/*file               controllers.Assets.versioned(path="/public", file: Asset)
 
 GET     /management/healthcheck     controllers.Management.healthcheck

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -11,3 +11,7 @@ addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.9")
 addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.1.0-M13")
 
 addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.10.0-RC1")
+
+addSbtPlugin("com.typesafe.sbt" % "sbt-digest" % "1.1.4")
+
+addSbtPlugin("com.typesafe.sbt" % "sbt-gzip" % "1.0.2")


### PR DESCRIPTION
Replaces #38 

## What does this change?

Configures digests of assets and changes to using the versioned assets controller. In other services, this helps ensure caching is done appropriately, and although s3-uploader is not behind a CDN it will use the same behaviour as our other services where we are enabling versioned assets.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

Check that assets (js, css, favicon) load as expected. Open the network tab and see asset filenames include md5 of file content.
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

No regressions.
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

- [ ] [Tested with screen reader](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#screen-readers)
- [ ] [Navigable with keyboard](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#keyboard-navigation)
- [ ] [Colour contrast passed](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#colour-contrast)
- [ ] [The change doesn't use only colour to convey meaning](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#use-of-colour)
