### PR TITLE
Fix a few critical vulnerabilities

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -18,7 +18,8 @@ libraryDependencies ++= Seq(
 )
 
 dependencyOverrides ++= Seq (
-  "org.bouncycastle" % "bcprov-jdk15on" % "1.67"
+  "org.bouncycastle" % "bcprov-jdk15on" % "1.67",
+  "com.fasterxml.jackson.core" % "jackson-databind" % "2.11.4",
 )
 
 lazy val root = (project in file("."))

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import PlayKeys._
 
 name := "s3-uploader"
 version := "1.0"
-scalaVersion := "2.13.7"
+scalaVersion := "2.13.10"
 
 scalacOptions := Seq(
   "-unchecked",

--- a/build.sbt
+++ b/build.sbt
@@ -13,8 +13,8 @@ scalacOptions := Seq(
 
 libraryDependencies ++= Seq(
   ws, filters,
-  "com.amazonaws" % "aws-java-sdk-s3" % "1.11.539",
-  "com.gu" %% "pan-domain-auth-verification" % "1.0.6"
+  "com.amazonaws" % "aws-java-sdk-s3" % "1.12.351",
+  "com.gu" %% "pan-domain-auth-verification" % "1.2.0"
 )
 
 dependencyOverrides ++= Seq (

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,13 +4,11 @@ resolvers += "Typesafe repository" at "https://repo.typesafe.com/typesafe/releas
 
 libraryDependencies += "org.vafer" % "jdeb" % "1.3" artifacts (Artifact("jdeb", "jar", "jar"))
 
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.11")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.18")
 
 addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.9")
 
 addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.1.0-M13")
-
-addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.10.0-RC1")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-digest" % "1.1.4")
 

--- a/public/js/package.json
+++ b/public/js/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "s3-uploader",
+  "name": "gu-s3-uploader",
   "version": "0.0.0",
   "description": "",
   "main": "",


### PR DESCRIPTION
## What does this change?

Fixes a few critical vulnerabilities, as reported by Snyk:

- Renames an internal project in `package.json` to avoid conflating it with an npm package which has a critical vulnerability
- Bumps Scala to 2.13.10 to fix a critical vulnerability
- Bumps a few other libraries that I've judged to be low-risk to fix a few high-priority vulnerabilities

## How to test

Deploy to CODE. Can we still upload files as usual?

Tested in CODE, uploading works as usual, as this [handsome goose attests.](https://s3-eu-west-1.amazonaws.com/uploads-origin.code.dev-guim.co.uk/2022/12/07/BBJW68_(c23749f83230ffe75f4c5c5e55d0dccc40d7ba40).jpg)