### PR TITLE
Update AMI to use ARM

### DIFF
--- a/conf/riff-raff.yaml
+++ b/conf/riff-raff.yaml
@@ -11,7 +11,7 @@ deployments:
     app: s3-uploader
     parameters:
       amiTags:
-        Recipe: editorial-tools-focal-java8
+        Recipe: editorial-tools-focal-java8-ARM
         AmigoStage: PROD
         BuiltBy: amigo
       cloudFormationStackName: s3-uploader


### PR DESCRIPTION
## What does this change?
This updates the AMI to use ARM OS in support of our move to AWS Graviton instances which are more performant and cheaper to run.

## How to test
This has been deployed to CODE and tested. This image of my cat was successfully uploaded using the new AMI deploy - https://s3-eu-west-1.amazonaws.com/uploads-origin.code.dev-guim.co.uk/2023/03/23/my-cat.jpg 