### PR TITLE
add Pinboard 📌

### DIFF
--- a/app/lib/Config.scala
+++ b/app/lib/Config.scala
@@ -30,6 +30,8 @@ trait Config {
 
   val loginUri = new URI(s"https://login.$domain/login?returnUrl=https://s3-uploader.$domain")
 
+  val pinboardLoaderUrl = new URI(s"https://pinboard.$domain/pinboard.loader.js")
+
   implicit val stage : String = {
     try {
       val stageFile = Source.fromFile("/etc/gu/stage")

--- a/app/views/main.scala.html
+++ b/app/views/main.scala.html
@@ -1,4 +1,5 @@
 @import com.gu.pandomainauth.model.User
+@import lib.S3UploadAppConfig
 @(user: User, title: String)(content: Html)
 
 <!DOCTYPE html>
@@ -41,5 +42,6 @@
         </div>
 
         <script src="@routes.Assets.versioned("js/node_modules/material-design-lite/material.min.js")"></script>
+        <script async src="@S3UploadAppConfig.pinboardLoaderUrl"></script>
     </body>
 </html>


### PR DESCRIPTION
Noticed when using s3-uploader that it would be useful to share the generated links after an upload to the piece(s) where they will be used... so added pinboard loader, easy peasy.

### TESTED on `CODE` ✅ 
![image](https://github.com/guardian/s3-upload/assets/19289579/f19d3930-1ff0-4fac-b4de-3e974892bd3c)
_oh hi Pinboard_ 👋