### PR TITLE
Send logs to central elk

### DIFF
--- a/conf/riff-raff.yaml
+++ b/conf/riff-raff.yaml
@@ -11,7 +11,7 @@ deployments:
     app: s3-uploader
     parameters:
       amiTags:
-        Recipe: editorial-tools-focal-java8-ARM
+        Recipe: editorial-tools-focal-java8-ARM-WITH-cdk-base
         AmigoStage: PROD
         BuiltBy: amigo
       cloudFormationStackName: s3-uploader


### PR DESCRIPTION
## What does this change?

Changes to the cdk-base AMI which should allow https://github.com/guardian/editorial-tools-platform/pull/720 to enable sending logs to central elk

It is possible that we will also need to add a logback.xml configuration