### PR TITLE
Remove backup S3 url

### DIFF
--- a/app/lib/S3Actions.scala
+++ b/app/lib/S3Actions.scala
@@ -11,34 +11,30 @@ import play.api.libs.functional.syntax._
 
 trait S3UploadResponse {
   def url: Option[URI]
-  def directToS3Url: Option[URI]
   def fileName : Option[String]
   def msg  : Option[String]
 }
 
-case class S3UploadSuccess(url: Option[URI], directToS3Url: Option[URI], fileName: Option[String], msg: Option[String])
+case class S3UploadSuccess(url: Option[URI], fileName: Option[String], msg: Option[String])
   extends S3UploadResponse
 
-case class S3UploadFailure(url: Option[URI], directToS3Url: Option[URI], fileName: Option[String], msg: Option[String])
+case class S3UploadFailure(url: Option[URI], fileName: Option[String], msg: Option[String])
   extends S3UploadResponse
 
 object S3UploadResponse {
   def buildSuccess(putObjectRequest: PutObjectRequest, config: Config) = {
-    val directToS3Uri = s"https://s3-eu-west-1.amazonaws.com/${putObjectRequest.getBucketName}/${putObjectRequest.getKey}"
-
     val uri = config.stage match {
       case "PROD" => s"${config.prettyUrl}/${putObjectRequest.getKey}"
-      case _ => directToS3Uri
+      case _ => s"https://s3-eu-west-1.amazonaws.com/${putObjectRequest.getBucketName}/${putObjectRequest.getKey}"
     }
     
-    S3UploadSuccess(Some(new URI(uri)), Some(new URI(directToS3Uri)), Some(putObjectRequest.getKey), None)
+    S3UploadSuccess(Some(new URI(uri)), Some(putObjectRequest.getKey), None)
   }
 
   implicit val writesUri: Writes[URI] = (uri: URI) => JsString(uri.toString)
 
   implicit val s3UploadSuccessWrites: Writes[S3UploadSuccess] = (
     (JsPath \ "url").writeNullable[URI] and
-    (JsPath \ "directToS3Url").writeNullable[URI] and
     (JsPath \ "fileName").writeNullable[String] and
     (JsPath \ "msg").writeNullable[String]
   )(unlift(S3UploadSuccess.unapply))
@@ -65,11 +61,11 @@ class S3Actions() {
 
         config.s3Client.putObject(finalRequest) match {
           case _: PutObjectResult => S3UploadResponse.buildSuccess(finalRequest, config)
-          case _ => S3UploadFailure(None, None, Some(file.getName), Some("Upload Failed"))
+          case _ => S3UploadFailure(None, Some(file.getName), Some("Upload Failed"))
         }
 
       }
-      case _ => S3UploadFailure(None, None, Some(file.getName), Some("File with that name already exists"))
+      case _ => S3UploadFailure(None, Some(file.getName), Some("File with that name already exists"))
     }
   }
 

--- a/app/views/uploaded.scala.html
+++ b/app/views/uploaded.scala.html
@@ -8,18 +8,15 @@
     <div class="results">
         <h3>Upload Results</h3>
         @s3Uploads.map {
-            case S3UploadSuccess(url, directToS3Url, fileName, msg) => {
+            case S3UploadSuccess(url, fileName, msg) => {
                 <p class="upload success">
                     Vanity URL <a href="@url">@url</a>
-                </p>
-                <p class="upload success">
-                    Backup URL (use this when fastly is down) <a href="@directToS3Url">@directToS3Url</a>
                 </p>
                 <p class="success">Successfully Uploaded!</p>
 
 
             }
-            case S3UploadFailure(None, None, fileName, msg) => {
+            case S3UploadFailure(None, fileName, msg) => {
                 <p class="upload failure">
                     @fileName
                 </p>


### PR DESCRIPTION
## What does this change?

Removes the Backup URL from the successful upload page:

<img width="959" alt="Screenshot 2023-09-15 at 11 45 32" src="https://github.com/guardian/s3-upload/assets/2619836/ed9416da-60ca-47ea-b849-eb62b0580d2e">

This URL should never need to be used. If Fastly is down, the website is down. Including this URL makes it easier for people to embed the wrong URL in composer.