### PR TITLE
Upgrade to Panda v5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ node_modules
 .DS_Store
 .metals
 .vscode
+.bsp/

--- a/app/lib/PanAuth.scala
+++ b/app/lib/PanAuth.scala
@@ -2,10 +2,11 @@ package lib
 
 
 import com.gu.pandomainauth.model.{Authenticated, AuthenticatedUser, AuthenticationStatus, User}
-import com.gu.pandomainauth.{PanDomain, PublicKey, PublicSettings}
+import com.gu.pandomainauth.{PanDomain, PublicSettings}
 import play.api.Logging
 import play.api.mvc._
 
+import java.security.PublicKey
 import scala.concurrent.{ExecutionContext, Future}
 
 class UserRequest[A](val user: User, request: Request[A]) extends WrappedRequest[A](request)

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import PlayKeys._
 
 name := "s3-uploader"
 version := "1.0"
-scalaVersion := "2.13.10"
+scalaVersion := "2.13.14"
 
 scalacOptions := Seq(
   "-unchecked",
@@ -14,7 +14,7 @@ scalacOptions := Seq(
 libraryDependencies ++= Seq(
   ws, filters,
   "com.amazonaws" % "aws-java-sdk-s3" % "1.12.761",
-  "com.gu" %% "pan-domain-auth-verification" % "4.0.0"
+  "com.gu" %% "pan-domain-auth-verification" % "5.0.0"
 )
 
 lazy val root = (project in file("."))

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.6
+sbt.version=1.10.1


### PR DESCRIPTION
This is pretty minor change, but does require a change to the imports for `PublicKey`, due to PR https://github.com/guardian/pan-domain-authentication/pull/147 and https://github.com/guardian/pan-domain-authentication/issues/153.

I've also bumped the Scala & sbt versions a tiny bit, added a gitignore line, tiny things!

### Testing

This has been [successfully deployed](https://riffraff.gutools.co.uk/deployment/view/d0198623-3de1-4b6b-8f5e-7f8eff455e93) to https://s3-uploader.code.dev-gutools.co.uk/, and I've verified that it still works:

https://github.com/user-attachments/assets/0bde7588-2791-4131-99db-fb173f49343f

