### PR TITLE
Add access permission logging

### DIFF
--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -10,9 +10,15 @@ import com.gu.pandomainauth.PublicSettings
 import lib._
 import play.api.mvc.{ControllerComponents, MaxSizeExceeded}
 import play.api.libs.json._
+import com.gu.permissions.PermissionsProvider
 
-class Application(s3Actions: S3Actions, override val publicSettings: PublicSettings,
-                  override val controllerComponents: ControllerComponents)(implicit mat: Materializer) extends PandaController {
+class Application(
+  s3Actions: S3Actions,
+  override val publicSettings: PublicSettings,
+  override val permissions: PermissionsProvider,
+  override val controllerComponents: ControllerComponents
+)(implicit mat: Materializer) extends PandaController {
+
   def index = AuthAction { request => {
       Ok(views.html.index(request.user)(request))
     }

--- a/app/lib/PanAuth.scala
+++ b/app/lib/PanAuth.scala
@@ -8,14 +8,24 @@ import play.api.mvc._
 
 import java.security.PublicKey
 import scala.concurrent.{ExecutionContext, Future}
+import com.gu.permissions.PermissionsProvider
+import com.gu.permissions.PermissionDefinition
 
 class UserRequest[A](val user: User, request: Request[A]) extends WrappedRequest[A](request)
 
 trait PandaController extends BaseControllerHelpers with Logging {
   def publicSettings: PublicSettings
 
-  def unauthorisedResponse[A](request: Request[A]) = {
+  def permissions: PermissionsProvider
+
+  val S3UploaderAccess = PermissionDefinition("s3_uploader_access", "s3-uploader")
+
+  def unauthenticatedResponse[A](request: Request[A]) = {
     Future.successful(Unauthorized(views.html.login(S3UploadAppConfig.loginUri)(request)))
+  }
+
+  def unauthorisedResponse[A](request: Request[A]) = {
+    Future.successful(Forbidden(views.html.unauthorised()(request)))
   }
 
   def authStatus(cookie: Cookie, publicKey: PublicKey): AuthenticationStatus = {
@@ -41,21 +51,24 @@ trait PandaController extends BaseControllerHelpers with Logging {
             case Some(cookie) =>
               authStatus(cookie, pk) match {
                 case Authenticated(AuthenticatedUser(user, _, _, _, _)) =>
+                  if (!permissions.hasPermission(S3UploaderAccess, user.email)) {
+                    logger.warn(s"User ${user.email} does not have ${S3UploaderAccess.name} permission")
+                  }
                   block(new UserRequest(user, request))
 
                 case other =>
                   logger.info(s"Login response $other")
-                  unauthorisedResponse(request)
+                  unauthenticatedResponse(request)
               }
 
             case None =>
               logger.warn("Panda cookie missing")
-              unauthorisedResponse(request)
+              unauthenticatedResponse(request)
           }
 
         case None =>
           logger.error("Panda public key unavailable")
-          unauthorisedResponse(request)
+          unauthenticatedResponse(request)
       }
     }
   }

--- a/app/views/unauthorised.scala.html
+++ b/app/views/unauthorised.scala.html
@@ -1,0 +1,35 @@
+@()(implicit request: RequestHeader)
+
+<!DOCTYPE html>
+
+<html lang="en">
+    <head>
+        <title>Unauthorised | S3 Uploader</title>
+        <link rel="shortcut icon" type="image/png" href="@routes.Assets.versioned("images/favicon.png")">
+        <link rel="stylesheet" href="@routes.Assets.versioned("js/node_modules/material-design-lite/material.min.css")">
+        <link rel="stylesheet" media="screen" href="@routes.Assets.versioned("stylesheets/main.css")">
+        <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
+    </head>
+
+    <body>
+        <div class="layout mdl-layout mdl-color--grey-100 mdl-js-layout mdl-layout--fixed-header">
+            <header class="mdl-layout__header mdl-color--grey-100 mdl-color-text--grey-600">
+                <div class="mdl-layout__header-row">
+                    <span class="mdl-layout-title">Unauthorised</span>
+                    <div class="mdl-layout-spacer"></div>
+                    S3 Uploader
+                </div>
+            </header>
+            <main class="page-content mdl-layout__content mdl-color--grey-100">
+                <h2 class="not-authed">
+                    You're logged in, but you've not been granted access to the S3 Uploader.
+                </h2>
+                <p>
+                    If you need to use this tool, please contact <a href="mailto:central.production@@theguardian.com">Central Production</a> to request access.
+                </p>
+            </main>
+        </div>
+
+        <script src="@routes.Assets.versioned("js/node_modules/material-design-lite/material.min.js")"></script>
+    </body>
+</html>

--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,8 @@ scalacOptions := Seq(
 libraryDependencies ++= Seq(
   ws, filters,
   "com.amazonaws" % "aws-java-sdk-s3" % "1.12.761",
-  "com.gu" %% "pan-domain-auth-verification" % "5.0.0"
+  "com.gu" %% "pan-domain-auth-verification" % "5.0.0",
+  "com.gu" %% "editorial-permissions-client" % "3.0.0"
 )
 
 lazy val root = (project in file("."))


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Adds a permission to access S3 uploader, currently logging only. Enforcement in a future PR, after analysing the intended effects.