### PR TITLE
move the pretty url into config under a new property `prettyBaseUrl`

### DIFF
--- a/app/lib/Config.scala
+++ b/app/lib/Config.scala
@@ -17,7 +17,7 @@ trait Config {
   val region: String
   val s3Client: AmazonS3
   def key (fileName: String): String
-  val prettyUrl: String
+  val maybePrettyBaseUrl: Option[String]
 
   val properties: Map[String, String] = Try(Properties.fromPath("/etc/gu/s3-uploader.properties")).getOrElse(Map.empty)
 
@@ -50,7 +50,7 @@ object S3UploadAppConfig extends Config {
   val bucketName = properties.getOrElse("s3.bucket", "s3-uploader-dev-bucket")
   val region = properties.getOrElse("aws.region", "eu-west-1")
   val s3Client = AmazonS3ClientBuilder.standard().withRegion(region).withCredentials(awsCredentials).build()
-  val prettyUrl = "https://uploads.guim.co.uk"
+  val maybePrettyBaseUrl = properties.get("prettyBaseUrl")
 
   def key(fileName: String) = {
     val now = Calendar.getInstance().getTime
@@ -65,7 +65,7 @@ object ChartsToolConfig extends Config {
   val bucketName = properties.getOrElse("s3.chartBucket", "gdn-cdn")
   val region = properties.getOrElse("aws.chartRegion", "us-east-1")
   val s3Client = AmazonS3ClientBuilder.standard().withRegion(region).withCredentials(awsCredentials).build()
-  val prettyUrl = "https://interactive.guim.co.uk"
+  val maybePrettyBaseUrl = if (stage == "PROD") Some("https://interactive.guim.co.uk") else None
 
   def key(fileName: String) = {
     val now = Calendar.getInstance().getTime

--- a/app/lib/S3Actions.scala
+++ b/app/lib/S3Actions.scala
@@ -23,11 +23,13 @@ case class S3UploadFailure(url: Option[URI], fileName: Option[String], msg: Opti
 
 object S3UploadResponse {
   def buildSuccess(putObjectRequest: PutObjectRequest, config: Config) = {
-    val uri = config.stage match {
-      case "PROD" => s"${config.prettyUrl}/${putObjectRequest.getKey}"
-      case _ => s"https://s3-eu-west-1.amazonaws.com/${putObjectRequest.getBucketName}/${putObjectRequest.getKey}"
+    val uri = config.maybePrettyBaseUrl match {
+      case Some(prettyBaseUrl) =>
+        s"$prettyBaseUrl/${putObjectRequest.getKey}"
+      case None =>
+        s"https://s3-eu-west-1.amazonaws.com/${putObjectRequest.getBucketName}/${putObjectRequest.getKey}"
     }
-    
+
     S3UploadSuccess(Some(new URI(uri)), Some(putObjectRequest.getKey), None)
   }
 


### PR DESCRIPTION
…(because its arguably private, but we can vary by stage just as nicely there) but leaving the chart stuff logically equivalent.

The config value is passed into the properties file in the infrastructure definition, thanks to https://github.com/guardian/editorial-tools-platform/pull/845