### PR TITLE
Add pixel tracking

### DIFF
--- a/app/lib/Config.scala
+++ b/app/lib/Config.scala
@@ -43,6 +43,10 @@ trait Config {
       case e: FileNotFoundException => "DEV"
     }
   }
+
+  val telemetryUrl =
+    s"https://user-telemetry.$domain/guardian-tool-accessed?app=s3-upload&stage=$stage"
+
 }
 
 

--- a/app/views/main.scala.html
+++ b/app/views/main.scala.html
@@ -1,6 +1,6 @@
 @import com.gu.pandomainauth.model.User
 @import lib.S3UploadAppConfig
-@(user: User, title: String)(content: Html)
+@(user: User, title: String, maybeTelemetryUrl: Option[String] = None)(content: Html)
 
 <!DOCTYPE html>
 
@@ -43,5 +43,9 @@
 
         <script src="@routes.Assets.versioned("js/node_modules/material-design-lite/material.min.js")"></script>
         <script async src="@S3UploadAppConfig.pinboardLoaderUrl"></script>
+        <script type="module">
+            const image = new Image();
+            image.src = `@Html(S3UploadAppConfig.telemetryUrl)&path=${window.location.pathname}`;
+        </script>
     </body>
 </html>

--- a/app/views/main.scala.html
+++ b/app/views/main.scala.html
@@ -1,6 +1,6 @@
 @import com.gu.pandomainauth.model.User
 @import lib.S3UploadAppConfig
-@(user: User, title: String, maybeTelemetryUrl: Option[String] = None)(content: Html)
+@(user: User, title: String)(content: Html)
 
 <!DOCTYPE html>
 


### PR DESCRIPTION
## What does this change?

This PR adds tracking to the s3-uploader using the [user-telemetry tracking pixel](https://github.com/guardian/editorial-tools-user-telemetry-service?tab=readme-ov-file#tracking-pixel). This will allow us to find out more about the usage of the tool. On merge, results should be visible in the [tool audit dashboard](https://metrics.gutools.co.uk/d/aegzv59r9eghsd/tool-audit?orgId=1&var-domain=s3-uploader.gutools.co.uk&var-path=All&var-interval=1d&var-chosen_apps=All&var-chosen_stacks=All&var-owners=All).

The PR generates the stage-specific telemetry URL based on the `domain` property of the configuration and passes it on to the Twirl HTML templates where a pixel tracking image is added.

## How to test

Running on CODE, you should see request for the pixel in the network tab on every page that requires authentication - for example, the index page and the upload result page.  
![Screenshot 2025-06-10 at 09 36 11](https://github.com/user-attachments/assets/eb9aaf9f-a5de-4397-9aa6-7ecfb02b9ef7)

## How can we measure success?

We have a clear idea how much the tool is being used. 