### PR TITLE
Add Jackson as a dependency to bump its version to 2.15

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -15,7 +15,8 @@ libraryDependencies ++= Seq(
   ws, filters,
   "com.amazonaws" % "aws-java-sdk-s3" % "1.12.761",
   "com.gu" %% "pan-domain-auth-verification" % "7.0.0",
-  "com.gu" %% "editorial-permissions-client" % "3.0.0"
+  "com.gu" %% "editorial-permissions-client" % "3.0.0",
+  "com.fasterxml.jackson.core" % "jackson-core" % "2.15.4"
 )
 
 resolvers ++= Resolver.sonatypeOssRepos("releases")


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

This pull request adds Jackson as a dependency so that we can bump it to v2.15 to address the [vulnerability](https://github.com/advisories/GHSA-h46c-h94j-95f3) in Jackson v2.14.

The Jackson is a transitive dependency from Play framework.  We are using Play 3.0.4 and the latest version on Play 3.0 branch still depends on Jackson 2.14.

Therefore we have to add it as a dependency to use a newer version.  Version 2.15.4 is the latest version on the 2.15 branch.

## How to test

Deployed to CODE and I could open the s3-upload and upload a text file successfully.

## How can we measure success?

Remove the high severity vulnerability from the dependency vulnerabilities dashboard. 

<img width="1226" height="66" alt="Screenshot 2025-07-17 at 16 18 29" src="https://github.com/user-attachments/assets/2a761ee1-1e0c-4237-9253-0db404009367" />