### PR TITLE
Upgrade com.fasterxml.jackson.core:jackson-core to version 2.21.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -16,7 +16,7 @@ libraryDependencies ++= Seq(
   "software.amazon.awssdk" % "s3" % "2.35.6",
   "com.gu" %% "pan-domain-auth-verification" % "13.0.0",
   "com.gu" %% "editorial-permissions-client" % "5.0.0",
-  "com.fasterxml.jackson.core" % "jackson-core" % "2.15.4"
+  "com.fasterxml.jackson.core" % "jackson-core" % "2.21.1"
 )
 
 resolvers ++= Resolver.sonatypeOssRepos("releases")


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

This is to Upgrade  com.fasterxml.jackson.core:jackson-core to version 2.21.1

This is to fix the high severity vulnerability raised by dependabot for jackson-core: [Number Length Constraint Bypass in Async Parser Leads to Potential DoS Condition](https://github.com/guardian/s3-upload/security/dependabot/16)

<img width="1501" height="527" alt="image" src="https://github.com/user-attachments/assets/a3f985c9-2816-400a-a82d-2fdf454a59e9" />


## How has this change been tested?

<!-- For example, have you deployed your branch to `CODE` and tested certain functionality or is unit testing sufficent for this change? If you'd like help testing your changes as part of the PR review process then mention that explicitly here. -->
1. Deploy to CODE
2. Log in and try to upload an image 
3. It should succed and should provide a Vanity URL

## Images
<img width="962" height="164" alt="image" src="https://github.com/user-attachments/assets/4543cddf-c113-4065-ba45-9132ed2d3440" />
