### PR TITLE
add override to netty-codec-http and netty-codec-http2 to 4.1.132.Final

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,12 +11,16 @@ scalacOptions := Seq(
   "-Xfatal-warnings"
 )
 
+  val nettyVersion = "4.1.132.Final"
+
 libraryDependencies ++= Seq(
   ws, filters,
   "software.amazon.awssdk" % "s3" % "2.35.6",
   "com.gu" %% "pan-domain-auth-verification" % "13.0.0",
   "com.gu" %% "editorial-permissions-client" % "5.0.0",
-  "com.fasterxml.jackson.core" % "jackson-core" % "2.21.1"
+  "com.fasterxml.jackson.core" % "jackson-core" % "2.21.1",
+  "io.netty" % "netty-codec-http" % nettyVersion,
+  "io.netty" % "netty-codec-http2" % nettyVersion
 )
 
 resolvers ++= Resolver.sonatypeOssRepos("releases")

--- a/build.sbt
+++ b/build.sbt
@@ -11,16 +11,12 @@ scalacOptions := Seq(
   "-Xfatal-warnings"
 )
 
-  val nettyVersion = "4.1.132.Final"
-
 libraryDependencies ++= Seq(
   ws, filters,
-  "software.amazon.awssdk" % "s3" % "2.35.6",
+  "software.amazon.awssdk" % "s3" % "2.42.41",
   "com.gu" %% "pan-domain-auth-verification" % "13.0.0",
   "com.gu" %% "editorial-permissions-client" % "5.0.0",
-  "com.fasterxml.jackson.core" % "jackson-core" % "2.21.1",
-  "io.netty" % "netty-codec-http" % nettyVersion,
-  "io.netty" % "netty-codec-http2" % nettyVersion
+  "com.fasterxml.jackson.core" % "jackson-core" % "2.21.1"
 )
 
 resolvers ++= Resolver.sonatypeOssRepos("releases")


### PR DESCRIPTION
## What does this change?

overrides to address:
https://github.com/advisories/GHSA-w9fj-cfpg-grvv
https://github.com/advisories/GHSA-pwqr-wmgm-9rr8

## How has this change been tested?

have deployed to code and uploaded an image
