### PR TITLE
Update pan-domain-auth-verification and AWS SDK to latest

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,7 @@ scalacOptions := Seq(
 libraryDependencies ++= Seq(
   ws, filters,
   "software.amazon.awssdk" % "s3" % "2.42.41",
-  "com.gu" %% "pan-domain-auth-verification" % "13.0.0",
+  "com.gu" %% "pan-domain-auth-verification" % "19.0.0",
   "com.gu" %% "editorial-permissions-client" % "5.0.0",
   "com.fasterxml.jackson.core" % "jackson-core" % "2.21.1"
 )

--- a/build.sbt
+++ b/build.sbt
@@ -13,7 +13,7 @@ scalacOptions := Seq(
 
 libraryDependencies ++= Seq(
   ws, filters,
-  "software.amazon.awssdk" % "s3" % "2.42.41",
+  "software.amazon.awssdk" % "s3" % "2.44.10",
   "com.gu" %% "pan-domain-auth-verification" % "19.0.0",
   "com.gu" %% "editorial-permissions-client" % "5.0.0",
   "com.fasterxml.jackson.core" % "jackson-core" % "2.21.1"


### PR DESCRIPTION
## What does this change?

This PR updates our dependencies on pan-domain-authentication and the AWS SDK to the latest available versions to resolve some vulnerabilities identified by dependabot.

## How has this change been tested?

 I’ve confirmed that the vulnerable transitive dependencies no longer show up the sbt dependency tree on this branch, and that I can log in locally and upload a file to S3 apparently successfully. The resulting file doesn’t seem to be publicly available, but I think this is probably a quirk of the dev environment – I’ll test in CODE to confirm.